### PR TITLE
Use RSpec mocks' argument matcher rather than ==

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rspec-activejob (0.0.1)
       activejob (>= 4.2)
+      rspec-mocks
 
 GEM
   remote: https://rubygems.org/

--- a/rspec-activejob.gemspec
+++ b/rspec-activejob.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
 
   s.add_runtime_dependency('activejob', '>= 4.2')
+  s.add_runtime_dependency('rspec-mocks')
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('rspec-its')

--- a/spec/rspec/active_job/matchers_spec.rb
+++ b/spec/rspec/active_job/matchers_spec.rb
@@ -51,9 +51,11 @@ RSpec.describe RSpec::ActiveJob::Matchers::EnqueueA do
   context "with argument expectations" do
     let(:job_class) { AJob }
     let(:instance) { described_class.new(job_class).with(*arguments) }
-    let(:arguments) { ['thing', 'other_thing'] }
+    let(:arguments) { [instance_of(BJob), hash_including(thing: 1)] }
 
-    let(:proc) { -> { enqueued_jobs << { job: AJob, args: arguments } } }
+    let(:proc) do
+      -> { enqueued_jobs << { job: AJob, args: [BJob.new, { thing: 1, 'thing' => 2 }] } }
+    end
 
     it { is_expected.to be(true) }
 


### PR DESCRIPTION
Means can support stuff like `expect { thing }.to enqueue_a(Job).with(instance_of(Model), anything, hash_including(cool: 'things'))`