### PR TITLE
Rails 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0 - Unreleased
+
+- Added the `deserialize_as` matcher
+
+## 0.2.0 - January 21, 2015
+
+- Added the `global_id` matcher
+
 ## 0.1.0 - January 18, 2015
 
 - Added support for argument matchers (e.g. `instance_of`, `hash_including`), like the `receive` matcher.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-activejob (0.2.0)
+    rspec-activejob (0.3.0)
       activejob (>= 4.2)
       rspec-mocks
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activejob (4.2.0)
-      activesupport (= 4.2.0)
+    activejob (4.2.1)
+      activesupport (= 4.2.1)
       globalid (>= 0.3.0)
-    activesupport (4.2.0)
+    activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -19,7 +19,7 @@ GEM
       tzinfo (~> 1.1)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    globalid (0.3.0)
+    globalid (0.3.3)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
     json (1.8.2)
@@ -29,23 +29,24 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.2)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-its (1.1.0)
+      rspec-support (~> 3.2.0)
+    rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
     slop (3.6.0)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -53,6 +54,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   pry
   rspec
   rspec-activejob!

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ end
 
 rspec-activejob expects the current queue adapter to expose an array of `enqueued_jobs`, like the included
 test adapter. The test adapter included in ActiveJob 4.2.0 does not fully serialize its arguments, so you
-will not need to use the GlobalID matcher until ActiveJob 4.2.1. See rails/rails#18266 for the improved
-test adapter.
+will not need to use the GlobalID matcher unless you're using ActiveJob 4.2.1. See rails/rails#18266 for 
+the improved test adapter.
 
-This gem defines two matchers:
+This gem defines three matchers:
 
 * `enqueue_a`: for a block or proc, expects that to enqueue an job to the ActiveJob test adapter. Optionally
   takes the job class as its argument, and can be modified with a `.with(*args)` call to expect specific arguments.
@@ -43,6 +43,8 @@ This gem defines two matchers:
   the serialized version of any instance of that model; if you pass an instance, it will expect the serialized
   version of that specific instance.
 
+* `deserialize_as(hash)`: an argument matcher, matching ActiveJob-serialized versions of hashes (with
+  string/symbol keys, or with indifferent access).
 
 With the `global_id` matcher it's important to note that it's specific to ActiveJob-serialized GlobalIDs.
 ActiveJob serializes them as a hash like `{ '_aj_global_id' => 'gid://my-app/MyModel/ID123' }`, to avoid

--- a/lib/rspec/active_job.rb
+++ b/lib/rspec/active_job.rb
@@ -1,5 +1,6 @@
 require 'rspec/active_job/enqueue_a'
 require 'rspec/active_job/global_id'
+require 'rspec/active_job/deserialize_as'
 
 module RSpec
   module ActiveJob
@@ -9,6 +10,10 @@ module RSpec
 
     def global_id(expected)
       Matchers::GlobalID.new(expected)
+    end
+
+    def deserialize_as(expected)
+      Matchers::DeserializeAs.new(expected)
     end
   end
 end

--- a/lib/rspec/active_job/deserialize_as.rb
+++ b/lib/rspec/active_job/deserialize_as.rb
@@ -1,0 +1,29 @@
+require 'active_job/arguments'
+require 'active_support/core_ext/hash/indifferent_access'
+
+module RSpec
+  module ActiveJob
+    module Matchers
+      class DeserializeAs
+        def initialize(expected)
+          @expected = expected
+        end
+
+        def ===(other)
+          deserialize(other).class == @expected.class &&
+            deserialize(other) == @expected
+        end
+
+        def description
+          "an object deserializing to #{@expected}"
+        end
+
+        private
+
+        def deserialize(argument)
+          ::ActiveJob::Arguments.deserialize([argument]).first
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/active_job/version.rb
+++ b/lib/rspec/active_job/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module ActiveJob
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end

--- a/rspec-activejob.gemspec
+++ b/rspec-activejob.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |s|
   s.summary = 'RSpec matchers to test ActiveJob'
   s.description = <<-EOL
     RSpec matchers for ActiveJob:
-    * expect { method }.to enqueue_a(MyJob).with('some', 'arguments')
+    * expect { method }.to enqueue_a(MyJob).with(global_id(some_model),
+                                                 deserialize_as(other_argument))
   EOL
   s.homepage = 'http://github.com/gocardless/rspec-activejob'
   s.license = 'MIT'
@@ -23,4 +24,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('rspec-its')
+  s.add_development_dependency('activesupport')
 end

--- a/spec/rspec/active_job/deserialize_as_spec.rb
+++ b/spec/rspec/active_job/deserialize_as_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe RSpec::ActiveJob::Matchers::DeserializeAs do
+  let(:instance) { described_class.new(expected) }
+  subject(:matches?) { instance === actual }
+
+  context "with an indifferent hash" do
+    let(:actual) do
+      { 'key' => 'value', '_aj_hash_with_indifferent_access' => true }
+    end
+    let(:expected) { ActiveSupport::HashWithIndifferentAccess.new(key: 'value') }
+
+    it { is_expected.to be(true) }
+
+    context "with a non-indifferent hash serialized" do
+      let(:actual) { { 'key' => 'value', '_aj_symbol_keys' => [] } }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  context "with a string-keyed hash" do
+    let(:expected) { { 'key' => 'value' } }
+    let(:actual) { { 'key' => 'value', '_aj_symbol_keys' => [] } }
+
+    it { is_expected.to be(true) }
+
+    context "with an indifferent hash serialized" do
+      let(:actual) do
+        { 'key' => 'value', '_aj_hash_with_indifferent_access' => true }
+      end
+      it { is_expected.to be(false) }
+    end
+
+    context "with a symbol keyed hash serialized" do
+      let(:actual) { { 'key' => 'value', '_aj_symbol_keys' => ['key'] } }
+      it { is_expected.to be(false) }
+    end
+  end
+
+  context "with a symbol-keyed hash" do
+    let(:expected) { { key: 'value' } }
+    let(:actual) { { 'key' => 'value', '_aj_symbol_keys' => ['key'] } }
+
+    it { is_expected.to be(true) }
+
+    context "with an indifferent hash serialized" do
+      let(:actual) do
+        { 'key' => 'value', '_aj_hash_with_indifferent_access' => true }
+      end
+      it { is_expected.to be(false) }
+    end
+
+    context "with a string keyed hash serialized" do
+      let(:actual) { { 'key' => 'value', '_aj_symbol_keys' => [] } }
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
Add a `deserialize_as` matcher to deal with 4.2.1's new hash serialization behaviour