### PR TITLE
Add `to_run_at` to EnqueueA matcher to support checking of execution time

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RSpec.describe MyController do
   subject(:make_request) { described_class.make_request(params) }
 
   specify { expect { make_request }.to enqueue_a(RequestMaker).with(global_id(user)) }
-  
+
   # or
   make_request
   expect(RequestMaker).to have_been_enqueued.with(global_id(user))
@@ -48,7 +48,7 @@ end
 
 rspec-activejob expects the current queue adapter to expose an array of `enqueued_jobs`, like the included
 test adapter. The test adapter included in ActiveJob 4.2.0 does not fully serialize its arguments, so you
-will not need to use the GlobalID matcher unless you're using ActiveJob 4.2.1. See rails/rails#18266 for 
+will not need to use the GlobalID matcher unless you're using ActiveJob 4.2.1. See rails/rails#18266 for
 the improved test adapter.
 
 This gem defines four matchers:
@@ -56,6 +56,7 @@ This gem defines four matchers:
 * `enqueue_a`: for a block or proc, expects that to enqueue an job to the ActiveJob test adapter. Optionally
   takes the job class as its argument, and can be modified with a `.with(*args)` call to expect specific arguments.
   This will use the same argument list matcher as rspec-mocks' `receive(:message).with(*args)` matcher.
+  If your job uses `set(wait_until: time)`, you can use `.to_run_at(time)` chain after `enqueue_a` call as well.
 
 * `have_been_enqueued`: expects to have enqueued an job in the ActiveJob test adapter. Can be modified with a `.with(*args)` call to expect specific arguments. This will use the same argument list matcher as rspec-mocks' `receive(:message).with(*args)` matcher.
 

--- a/spec/rspec/active_job/enqueue_a_spec.rb
+++ b/spec/rspec/active_job/enqueue_a_spec.rb
@@ -148,4 +148,31 @@ RSpec.describe RSpec::ActiveJob::Matchers::EnqueueA do
       end
     end
   end
+
+  context "with run time expectations" do
+    let(:instance) { described_class.new }
+    let(:run_time) { Time.parse('2015-09-10 00:00:00 UTC').to_f }
+    subject(:matches?) { instance.to_run_at(run_time).matches?(AJob) }
+
+    let(:enqueued_jobs) do
+      [{ job: AJob, args: [], at: time }]
+    end
+
+    context "correct time" do
+      let(:time) { run_time }
+      it { is_expected.to be(true) }
+    end
+
+    context "wrong time" do
+      let(:time) { run_time + 1 }
+      it { is_expected.to be(false) }
+
+      specify do
+        matches?
+        expect(instance.failure_message).
+          to eq("expected to run job at 2015-09-10 00:00:00 UTC, " \
+            "but enqueued to run at 2015-09-10 00:00:01 UTC")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is initial suggestion to solve #9 

Let's discuss if you want to get it working another way, or have more ideas how to solve it. 

Usage example: 
```
let(:time) { 1.day.from_now } # or unix time, what is more appropriate
expect { perform }.to enqueue_a(AJob).to_run_at(time)
```