### PR TITLE
Add a full spec for multiple jobs in the queue matcher

### DIFF
--- a/spec/rspec/active_job/enqueue_a_spec.rb
+++ b/spec/rspec/active_job/enqueue_a_spec.rb
@@ -124,7 +124,16 @@ RSpec.describe RSpec::ActiveJob::Matchers::EnqueueA do
 
       context "when it enqueues two jobs" do
         let(:enqueued_jobs) { [{ job: AJob, args: [] }, { job: BJob, args: [] }] }
-        it { is_expected.to be(true) }
+
+        context "matches first job" do
+          let(:job_class) { AJob }
+          it { is_expected.to be(true) }
+        end
+
+        context "matches second job" do
+          let(:job_class) { BJob }
+          it { is_expected.to be(true) }
+        end
       end
 
       context "with argument expectations" do


### PR DESCRIPTION
Hello, 

this is just a small addition to specs, because I wanted to test if the issue described in https://github.com/gocardless/rspec-activejob/issues/16 still exists.

Seems like not any longer (so you can close it), but I think it would be beneficial to add this small amendment to specs as well.