### PR TITLE
Allow matching amount of times the job was enqueued

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ This gem defines four matchers:
   takes the job class as its argument, and can be modified with a `.with(*args)` call to expect specific arguments.
   This will use the same argument list matcher as rspec-mocks' `receive(:message).with(*args)` matcher.
   If your job uses `set(wait_until: time)`, you can use `.to_run_at(time)` chain after `enqueue_a` call as well.
+  In order to check for the right number of enqueued jobs use a `.once` or `.times(n)` modifiers.
 
-* `have_been_enqueued`: expects to have enqueued an job in the ActiveJob test adapter. Can be modified with a `.with(*args)` call to expect specific arguments. This will use the same argument list matcher as rspec-mocks' `receive(:message).with(*args)` matcher.
+* `have_been_enqueued`: expects to have enqueued an job in the ActiveJob test adapter. Optionally accepts all the
+  same modifiers as `enqueue_a`.
 
 * `global_id(model_or_class)`: an argument matcher, matching ActiveJob-serialized versions of model classes or
   specific models (or any other class which implements `to_global_id`). If you pass a model class, it will match

--- a/spec/rspec/active_job/enqueue_a_spec.rb
+++ b/spec/rspec/active_job/enqueue_a_spec.rb
@@ -184,4 +184,58 @@ RSpec.describe RSpec::ActiveJob::Matchers::EnqueueA do
       end
     end
   end
+
+  context "with number of times expectations" do
+    let(:instance) { described_class.new }
+
+    context "once" do
+      subject(:matches?) { instance.once.matches?(AJob) }
+
+      context "correct number of times" do
+        let(:enqueued_jobs) { [{ job: AJob, args: [] }] }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "wrong number of times" do
+        let(:enqueued_jobs) do
+          [{ job: AJob, args: [] }, { job: AJob, args: [] }]
+        end
+
+        it { is_expected.to be(false) }
+
+        specify do
+          matches?
+          expect(instance.failure_message).
+            to eq("expected to enqueue a AJob once, but enqueued 2 times")
+        end
+      end
+    end
+
+    context "mutiple times" do
+      subject(:matches?) { instance.times(2).matches?(AJob) }
+
+      context "correct number of times" do
+        let(:enqueued_jobs) do
+          [{ job: AJob, args: [] }, { job: AJob, args: [] }]
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context "wrong number of times" do
+        let(:enqueued_jobs) do
+          [{ job: AJob, args: [] }]
+        end
+
+        it { is_expected.to be(false) }
+
+        specify do
+          matches?
+          expect(instance.failure_message).
+            to eq("expected to enqueue a AJob 2 times, but enqueued once")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hey,

This PR adds the ability to match against the number of times the job was enqueued with `.once` or `.times(n)` modifiers.