### PR TITLE
Detect enqueuing of job already in the queue

### DIFF
--- a/lib/rspec/active_job/enqueue_a.rb
+++ b/lib/rspec/active_job/enqueue_a.rb
@@ -137,7 +137,9 @@ module RSpec
         end
 
         def new_jobs
-          enqueued_jobs - @before_jobs
+          result = enqueued_jobs.dup
+          @before_jobs.each { |job| result.delete_at(result.index(job)) }
+          result
         end
 
         def new_jobs_with_correct_class

--- a/spec/rspec/active_job/enqueue_a_spec.rb
+++ b/spec/rspec/active_job/enqueue_a_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe RSpec::ActiveJob::Matchers::EnqueueA do
 
         it { is_expected.to be(true) }
       end
+
+      context "when it enqueues a job with the same arguments as an existing job" do
+        before { enqueued_jobs << { job: AJob, args: [] } }
+        let(:proc) do
+          -> { enqueued_jobs << { job: AJob, args: [] } }
+        end
+
+        it { is_expected.to be(true) }
+      end
     end
 
     context "with argument expectations" do


### PR DESCRIPTION
There are cases when you want to detect the enqueuing of a job already in the queue. 

The previous implementation detected new jobs with
```ruby
enqueued_jobs - @before_jobs
```
which fails to detect a job that is the same as a job already in the queue. A simple demonstration of this behavior in ruby is
```ruby
[1,1] - [1] # => []
```

We change the implementation of `new_jobs` to detect these additional duplicate jobs.