### PR TITLE
update gemspec and travis to support rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,24 @@
 language: ruby
 rvm:
-  - 2.2
-  - 2.1
-  - 2.0
-  - 1.9
-  - jruby-19mode
+  - "2.3.1"
+  - "2.2.2"
+  - "2.1"
+  - "2.0"
+  - "1.9"
+  - "jruby-19mode"
+gemfile:
+  - Gemfile.activejob42
+  - Gemfile.activejob50
+matrix:
+  exclude:
+    - rvm: "jruby-19mode"
+      gemfile: Gemfile.activejob50
+    - rvm: "1.9"
+      gemfile: Gemfile.activejob50
+    - rvm: "2.0"
+      gemfile: Gemfile.activejob50
+    - rvm: "2.1"
+      gemfile: Gemfile.activejob50
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/Gemfile.activejob42
+++ b/Gemfile.activejob42
@@ -2,3 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'activejob', '~> 4.2.0'
+
+group :test do
+  gem 'pry'
+end

--- a/Gemfile.activejob42
+++ b/Gemfile.activejob42
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'activejob', '~> 4.2.0'

--- a/Gemfile.activejob50
+++ b/Gemfile.activejob50
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'activejob', '~> 5.0.0'
+

--- a/Gemfile.activejob50
+++ b/Gemfile.activejob50
@@ -3,3 +3,6 @@ gemspec
 
 gem 'activejob', '~> 5.0.0'
 
+group :test do
+  gem 'pry'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rspec-activejob (0.6.1)
-      activejob (>= 4.2)
+      activejob (>= 4.2, < 5.1.0)
       rspec-mocks
 
 GEM
@@ -22,7 +22,7 @@ GEM
       parser (~> 2.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    globalid (0.3.3)
+    globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
     json (1.8.2)
@@ -76,4 +76,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.10.6
+   1.12.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,9 +17,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    ast (2.1.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
+    ast (2.3.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     globalid (0.3.6)
@@ -28,14 +26,14 @@ GEM
     json (1.8.2)
     method_source (0.8.2)
     minitest (5.5.1)
-    parser (2.2.2.6)
-      ast (>= 1.1, < 3.0)
+    parser (2.3.1.2)
+      ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rainbow (2.0.0)
+    rainbow (2.1.0)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -52,17 +50,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    rubocop (0.34.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.2.5, < 3.0)
+    rubocop (0.41.1)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.7.5)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     slop (3.6.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode-display_width (1.1.0)
 
 PLATFORMS
   ruby
@@ -73,7 +72,7 @@ DEPENDENCIES
   rspec
   rspec-activejob!
   rspec-its
-  rubocop
+  rubocop (~> 0.41)
 
 BUNDLED WITH
    1.12.4

--- a/lib/rspec/active_job/enqueue_a.rb
+++ b/lib/rspec/active_job/enqueue_a.rb
@@ -14,12 +14,11 @@ module RSpec
           if actual.is_a?(Proc)
             @before_jobs = enqueued_jobs.dup
             actual.call
-            all_checks_pass?
           else
             @job_class = actual
             @before_jobs = []
-            all_checks_pass?
           end
+          all_checks_pass?
         end
 
         def with(*args)

--- a/rspec-activejob.gemspec
+++ b/rspec-activejob.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec')
   s.add_development_dependency('rspec-its')
   s.add_development_dependency('activesupport')
-  s.add_development_dependency('rubocop')
+  s.add_development_dependency('rubocop', '~> 0.41')
 end

--- a/rspec-activejob.gemspec
+++ b/rspec-activejob.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.require_paths = %w(lib)
 
-  s.add_runtime_dependency('activejob', '>= 4.2')
+  s.add_runtime_dependency('activejob', '>= 4.2', '< 5.1.0')
   s.add_runtime_dependency('rspec-mocks')
 
   s.add_development_dependency('rspec')

--- a/spec/rspec/active_job/enqueue_a_spec.rb
+++ b/spec/rspec/active_job/enqueue_a_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe RSpec::ActiveJob::Matchers::EnqueueA do
         end
         it { is_expected.to be(true) }
 
-        context "with mismatching arguments"do
+        context "with mismatching arguments" do
           let(:enqueued_jobs) { [{ job: AJob, args: [] }] }
           it { is_expected.to be(false) }
           specify do


### PR DESCRIPTION
In an attempt to rectify the bundler conflict shown below, I've updated the gemspec dependencies and the test matrix to support Rails 4.2 and 5.0 branches. In the process, I've also corrected some Rubocop complaints. 

The proposed PR should fix the following conflict
```shell
Bundler could not find compatible versions for gem "activejob":
  In snapshot (Gemfile.lock):
    activejob (= 5.0.0.rc1)

  In Gemfile:
    rails (< 5.1, >= 5.0.0) was resolved to 5.0.0, which depends on
      activejob (= 5.0.0)

    rspec-activejob (~> 0.6.1) was resolved to 0.6.1, which depends on
      activejob (>= 4.2)
```