### PR TITLE
Add deprecation warning due to rspec-rails >3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 ![TravisCI status](https://travis-ci.org/gocardless/rspec-activejob.svg?branch=master)
+
+# Deprecated
+
+Since v3.5, `rspec-rails` defines matchers that provide the same functionality
+as those in `rspec-activejob`.  See
+[rspec-rails docs](https://relishapp.com/rspec/rspec-rails/v/3-5/docs/matchers/have-been-enqueued-matcher)
+for more detail.
+
 # Installation
 
 ```gem install rspec-activejob ```


### PR DESCRIPTION
`rspec-rails` now includes functionality that is a duplicate of this gem. Best to warn people before they depend on ours when they likely already have `rspec-rails` in their Gemfile.