### PR TITLE
Add .as modifier that checks the queue name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This gem defines four matchers:
 * `enqueue_a`: for a block or proc, expects that to enqueue an job to the ActiveJob test adapter. Optionally
   takes the job class as its argument, and can be modified with a `.with(*args)` call to expect specific arguments.
   This will use the same argument list matcher as rspec-mocks' `receive(:message).with(*args)` matcher.
+  To verify the queue name (useful when `queue_as` was passed a block) use `.as(queue_name)` modifier.
   If your job uses `set(wait_until: time)`, you can use `.to_run_at(time)` chain after `enqueue_a` call as well.
   In order to check for the right number of enqueued jobs use a `.once` or `.times(n)` modifiers.
 

--- a/spec/rspec/active_job/enqueue_a_spec.rb
+++ b/spec/rspec/active_job/enqueue_a_spec.rb
@@ -167,6 +167,32 @@ RSpec.describe RSpec::ActiveJob::Matchers::EnqueueA do
     end
   end
 
+  context "with queue name" do
+    let(:instance) { described_class.new }
+    let(:queue_name) { 'example_queue' }
+    subject(:matches?) { instance.as(queue_name).matches?(AJob) }
+
+    let(:enqueued_jobs) do
+      [{ job: AJob, args: [], queue: name }]
+    end
+
+    context "correct queue name" do
+      let(:name) { queue_name }
+      it { is_expected.to be(true) }
+    end
+
+    context "wrong queue name" do
+      let(:name) { 'wrong_queue' }
+      it { is_expected.to be(false) }
+
+      specify do
+        matches?
+        expect(instance.failure_message).
+          to eq("expected to enqueue as 'example_queue', enqueued as 'wrong_queue'")
+      end
+    end
+  end
+
   context "with run time expectations" do
     let(:instance) { described_class.new }
     let(:run_time) { Time.parse('2015-09-10 00:00:00 UTC').to_f }


### PR DESCRIPTION
This PR adds a new modifier — `.as(queue_name)`, allows to check that a job was enqueued using the right queue name. This is useful when queue name is dynamically determined in a block.
